### PR TITLE
Add root safety check to installer scripts

### DIFF
--- a/bootstrap-install.sh
+++ b/bootstrap-install.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ $EUID -ne 0 ]]; then
+    echo "This installer must be run as root." >&2
+    exit 1
+fi
+
 apt update
 apt install -y \
   zstd lz4 jq net-tools sysstat \

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -2,6 +2,11 @@
 set -e
 set -o pipefail
 
+if [[ $EUID -ne 0 ]]; then
+    echo "This installer must be run as root." >&2
+    exit 1
+fi
+
 NGINX_VERSION="1.28.0"
 OPENSSL_VERSION="openssl-3.3.1"
 BUILD_DIR="/tmp/nginx-build"

--- a/php/setup-fpm.sh
+++ b/php/setup-fpm.sh
@@ -2,6 +2,11 @@
 set -e
 set -o pipefail
 
+if [[ $EUID -ne 0 ]]; then
+    echo "This installer must be run as root." >&2
+    exit 1
+fi
+
 export DEBIAN_FRONTEND=noninteractive
 INSTALL_IONCUBE=${INSTALL_IONCUBE:-no}
 


### PR DESCRIPTION
## Summary
- ensure `bootstrap-install.sh` fails when not run as root
- add the same check to `nginx/setup.sh` and `php/setup-fpm.sh`

## Testing
- `shellcheck bootstrap-install.sh nginx/setup.sh php/setup-fpm.sh`
- `sudo -u nobody bash bootstrap-install.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f4caf30a4832d801dd345b8c26757