### PR TITLE
Add Redis Server setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Este projeto provisiona uma stack profissional de hospedagem em servidores Debia
 - Exporters para Prometheus (Node, NGINX, PHP, MariaDB)
 - Dashboard Grafana instalado e pronto para uso
 - Fail2Ban configurado para proteger o stack web
+- Redis Server instalado para cache e filas
 - Arquitetura modular, com scripts reutilizáveis e separados por contexto
 
 ### Público-alvo:
@@ -36,6 +37,7 @@ Este projeto provisiona uma stack profissional de hospedagem em servidores Debia
 - **ISPConfig** com pools otimizados por socket e template NGINX compatível com Laravel
 - **Prometheus + Grafana** com exporters para Node, NGINX, PHP-FPM e MariaDB
 - **Backups via Rclone + GDrive**
+- **Redis Server** instalado para cache e filas
 - Arquitetura modular, clara e reutilizável
 
 ---
@@ -47,6 +49,8 @@ Este projeto provisiona uma stack profissional de hospedagem em servidores Debia
 ├── bootstrap-install.sh       # Instalador principal
 ├── db/
 │   ├── 50-server-optimized-32gb.cnf
+│   └── redis/
+│       └── setup.sh
 ├── nginx/
 │   ├── setup.sh               # Compila e instala NGINX com todos os módulos
 │   ├── conf.d/                # Extras opcionais

--- a/bootstrap-install.sh
+++ b/bootstrap-install.sh
@@ -27,6 +27,9 @@ echo "\n Finalizado PHP-FPM"
 echo "\n Otimizando Maria DB..."
 cp -n ./db/50-server-optimized-32gb.cnf /opt/50-server-optimized-32gb.cnf
 
+echo "\n Instalando Redis Server..."
+bash ./db/redis/setup.sh
+
 
 echo "\n\n Executando instalador do ISPConfig..."
 bash ./ispconfig/main-install.sh

--- a/db/redis/setup.sh
+++ b/db/redis/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "\n📦 Instalando Redis Server..."
+apt update
+apt install -y redis-server
+
+systemctl enable redis-server
+systemctl start redis-server
+
+echo "Redis Server instalado e em execucao."


### PR DESCRIPTION
## Summary
- add Redis Server setup script in `db/redis`
- invoke the script from `bootstrap-install.sh`
- document Redis service in README with updated directory tree and bullet lists

## Testing
- `bash -n db/redis/setup.sh`
- `bash -n bootstrap-install.sh`
- `shellcheck` was unavailable


------
https://chatgpt.com/codex/tasks/task_e_684f4dd9597c832da98a837657cec381